### PR TITLE
Make autostart reliable on Raspberry Pi

### DIFF
--- a/start_weather.sh
+++ b/start_weather.sh
@@ -6,18 +6,21 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Change to the script directory
 cd "$SCRIPT_DIR"
 
-# Check if virtual environment exists
+# Redirect all output to a log so autostart failures are diagnosable
+exec >> "$SCRIPT_DIR/autostart.log" 2>&1
+echo "=== $(date) autostart start ==="
+
+# Create the virtual environment and install packages only once.
+# Doing this on every boot makes startup depend on the network being up,
+# which is the main cause of intermittent autostart failures.
 if [ ! -d ".venv" ]; then
-    echo "Creating virtual environment..."
+    echo "Creating virtual environment and installing packages..."
     python3 -m venv .venv
+    source .venv/bin/activate
+    pip install -r requirements.txt
+else
+    source .venv/bin/activate
 fi
-
-# Activate virtual environment
-source .venv/bin/activate
-
-# Install required packages
-echo "Installing required packages..."
-pip install -r requirements.txt
 
 # Check if .env file exists
 if [ ! -f ".env" ]; then
@@ -27,6 +30,17 @@ if [ ! -f ".env" ]; then
     exit 1
 fi
 
+# Wait for the X display to be ready instead of a fixed sleep.
+# A fixed delay races with the desktop on slow boots and the app crashes
+# with "couldn't connect to display".
+export DISPLAY="${DISPLAY:-:0}"
+for i in $(seq 1 60); do
+    if xset q >/dev/null 2>&1; then
+        echo "X display ready after ${i}s"
+        break
+    fi
+    sleep 1
+done
+
 # Start the weather program
-sleep 10 # wait seconds for destop loading
-python -m src.main 
+python -m src.main


### PR DESCRIPTION
## Problem

Boot-time autostart via `~/.config/autostart/weather-frame.desktop` was **intermittently failing** on the Raspberry Pi. The cause was timing races in `start_weather.sh` at boot.

## Causes & Fixes

1. **`pip install` ran on every boot** — when it ran before the network (WiFi) came up, the PyPI connection stalled or failed. → venv creation and package install now happen **only on first run**.
2. **Fixed `sleep 10` raced with X display readiness** — on slow boots Tk crashed with `couldn't connect to display`. → Replaced with a poll loop that waits for X up to 60s via `xset q`.
3. **Failures left no trace** — shell-level failures were invisible. → All output is now redirected to `autostart.log` for diagnosis.

## After Applying

- Executable bit: `chmod +x start_weather.sh`
- `xset` requires the `x11-xserver-utils` package (`sudo apt install x11-xserver-utils`)
- When `requirements.txt` changes, run `pip install -r requirements.txt` manually once

🤖 Generated with [Claude Code](https://claude.com/claude-code)