### PR TITLE
Show fullscreen window reliably under Wayland/labwc

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -41,7 +41,6 @@ class WeatherFrame(tk.Tk):
 
     def setup_window(self):
         self.title("Weather Frame")
-        self.attributes('-fullscreen', True)
         self.configure(bg='black')
         self.main_frame = tk.Frame(self, bg='black')
         self.main_frame.pack(expand=True, fill='both')
@@ -49,6 +48,23 @@ class WeatherFrame(tk.Tk):
         self.protocol("WM_DELETE_WINDOW", self.on_close)
         # Hide mouse cursor
         self.config(cursor="none")
+        # On Raspberry Pi OS Bookworm (Wayland/labwc via XWayland), setting
+        # -fullscreen before the window is mapped can leave the window
+        # unmapped: the app runs fine but no window ever appears. Because it
+        # races with the compositor being ready, it shows up only some boots.
+        # Map the window at screen size first, then assert fullscreen and
+        # raise it once the event loop is running.
+        self.geometry(f"{self.winfo_screenwidth()}x{self.winfo_screenheight()}+0+0")
+        self.after(200, self._enter_fullscreen)
+
+    def _enter_fullscreen(self):
+        try:
+            self.deiconify()
+            self.attributes('-fullscreen', True)
+            self.lift()
+            self.focus_force()
+        except tk.TclError as e:
+            logging.warning(f"Failed to enter fullscreen: {e}")
 
     def create_widgets(self):
         # Reuse the same HTTP session used by the API for icon fetching


### PR DESCRIPTION
## Problem

On Raspberry Pi OS Bookworm the desktop runs **Wayland (labwc)** and Tkinter renders through **XWayland**. `setup_window()` set `-fullscreen` *before* the window was mapped, which under labwc can leave the window unmapped — the app runs and fetches weather successfully (`weather_frame.log` shows repeated "Weather update successful"), but **no window ever appears**.

Because it races the compositor's readiness at boot, the window showed up only on *some* boots — this is the root cause of the intermittent "sometimes shows, sometimes doesn't" autostart behavior.

## Fix

Map the window at screen size first, then `deiconify()`, set `-fullscreen`, `lift()` and `focus_force()` once the event loop is running (deferred via `after()`).

## Verification

Tested on the actual Raspberry Pi (Bookworm / Wayland / labwc): the fullscreen window now appears reliably. `python -m py_compile` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)