### PR TITLE
Confine weather-update state changes to the main thread

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -88,6 +88,8 @@ class WeatherFrame(tk.Tk):
             logging.info(f"CPU usage: {process.cpu_percent()}%")
         except Exception as e:
             logging.error(f"Error logging system stats: {str(e)}")
+        finally:
+            self.after(300000, self.log_system_stats)  # Re-schedule every 5 minutes
 
     def start_updates(self):
         # update_weather and update_time each re-schedule themselves, so they
@@ -105,8 +107,9 @@ class WeatherFrame(tk.Tk):
         self.after(1000, self.update_time)
 
     def cleanup(self):
+        # log_system_stats() re-schedules itself every 5 minutes, so don't call
+        # it here too — that would fork a second timer chain.
         gc.collect()  # Force garbage collection
-        self.log_system_stats()
         self.after(3600000, self.cleanup)
 
     def update_weather(self):
@@ -140,43 +143,51 @@ class WeatherFrame(tk.Tk):
         future: Future = self.executor.submit(_fetch)
 
         def _on_done(fut: Future):
+            # Runs on a worker thread. Marshal everything back to the Tk main
+            # thread via ui_queue so shared state (consecutive_errors,
+            # is_fetching_weather, ...) is only ever touched from one thread.
             try:
                 weather_data: WeatherData = fut.result()
-                def _apply_update():
-                    self.weather_widgets.update_weather(weather_data)
-                    if self.consecutive_errors > 0:
-                        logging.info(f"Weather update successful after {self.consecutive_errors} failures.")
-                    else:
-                        logging.info("Weather update successful")
-                    self.consecutive_errors = 0
-                    self.last_successful_update = time.time()
-                # Queue for execution on Tk main thread
-                self.ui_queue.put(_apply_update)
-            except requests.exceptions.RequestException as req_err:
-                self.consecutive_errors += 1
-                error_type = type(req_err).__name__
-                error_msg = str(req_err)
-                log_level = logging.WARNING
-                if "NameResolutionError" in error_msg:
-                    log_level = logging.ERROR
-                    logging.error("DNS Resolution failed for api.openweathermap.org. Check network/DNS settings.")
-                else:
-                    logging.warning(f"API Request failed: {error_msg}")
-                logging.log(log_level, f"Error updating weather: {error_msg}")
-                logging.log(log_level, f"Full error details: {error_type}")
-                logging.log(log_level, f"Consecutive errors: {self.consecutive_errors}")
-            except Exception as e:
-                self.consecutive_errors += 1
-                logging.error(f"Unexpected error during weather update: {str(e)}", exc_info=True)
-                logging.error(f"Full error details: {type(e).__name__}")
-                logging.error(f"Consecutive errors: {self.consecutive_errors}")
+            except Exception as err:
+                self.ui_queue.put(lambda e=err: self._handle_weather_failure(e))
+            else:
+                self.ui_queue.put(lambda: self._handle_weather_success(weather_data))
             finally:
-                self.is_fetching_weather = False
-                # Schedule the next update on the Tk main thread
-                self.ui_queue.put(lambda: self.after(300000, self.update_weather))
+                self.ui_queue.put(self._finish_weather_cycle)
 
         # Attach completion callback without blocking main thread
         future.add_done_callback(_on_done)
+
+    def _handle_weather_success(self, weather_data: WeatherData):
+        self.weather_widgets.update_weather(weather_data)
+        if self.consecutive_errors > 0:
+            logging.info(f"Weather update successful after {self.consecutive_errors} failures.")
+        else:
+            logging.info("Weather update successful")
+        self.consecutive_errors = 0
+        self.last_successful_update = time.time()
+
+    def _handle_weather_failure(self, err: Exception):
+        self.consecutive_errors += 1
+        if isinstance(err, requests.exceptions.RequestException):
+            error_msg = str(err)
+            if "NameResolutionError" in error_msg:
+                log_level = logging.ERROR
+                logging.error("DNS Resolution failed for api.openweathermap.org. Check network/DNS settings.")
+            else:
+                log_level = logging.WARNING
+                logging.warning(f"API Request failed: {error_msg}")
+            logging.log(log_level, f"Error updating weather: {error_msg}")
+            logging.log(log_level, f"Full error details: {type(err).__name__}")
+            logging.log(log_level, f"Consecutive errors: {self.consecutive_errors}")
+        else:
+            logging.error(f"Unexpected error during weather update: {str(err)}", exc_info=err)
+            logging.error(f"Full error details: {type(err).__name__}")
+            logging.error(f"Consecutive errors: {self.consecutive_errors}")
+
+    def _finish_weather_cycle(self):
+        self.is_fetching_weather = False
+        self.after(300000, self.update_weather)
 
     def process_ui_queue(self):
         try:

--- a/src/ui/weather_widgets.py
+++ b/src/ui/weather_widgets.py
@@ -162,7 +162,7 @@ class WeatherWidgets:
         self.snow_label.config(text=f"🌨️ {snow:.1f}㎜/h" if snow > 0 else "")
 
         # Update temperature range for the first day of forecast
-        if weather_data.forecast and len(weather_data.forecast) > 0:
+        if weather_data.forecast:
             first_day = weather_data.forecast[0]
             self.temp_min_label.config(text=f"↓{round(first_day.temp_min)}°")
             self.temp_max_label.config(text=f"↑{round(first_day.temp_max)}°")


### PR DESCRIPTION
## Thread-safety (main fix)

The `Future` done-callback (`_on_done`) runs on a **worker thread**. The success path already marshalled its state changes onto the Tk main thread via `ui_queue`, but the **error** and **finally** paths mutated `consecutive_errors` and `is_fetching_weather` **directly from the worker thread** — while `update_weather()` reads them on the main thread. Mixing the two models is fragile (it only "works" thanks to the GIL).

Now every outcome is routed through `ui_queue`:
- `_handle_weather_success` — updates UI, resets `consecutive_errors`, records `last_successful_update`
- `_handle_weather_failure` — increments `consecutive_errors` and logs (same levels/messages as before; uses `exc_info=err` for unexpected errors)
- `_finish_weather_cycle` — clears `is_fetching_weather` and schedules the next run

Queue order guarantees the success/failure handler runs before the next update is scheduled, so `consecutive_errors` is current when the backoff logic next reads it.

## Also included

- **`log_system_stats()` now re-schedules itself every 5 minutes.** It was scheduled once in `start_updates()` but never re-armed, so it logged a single time at the 5-minute mark and then only hourly via `cleanup()`. `cleanup()` no longer calls it (that would now fork a second timer chain).
- **Drop a redundant `len() > 0`** check in `WeatherWidgets.update_weather` (`if forecast and len(forecast) > 0` → `if forecast`).

No external behavior change beyond the periodic system-stats logging. `python -m py_compile` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)